### PR TITLE
fix non-ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Code Author: Shannon E. Houck
 
 Updated: Nov. 21, 2019
 
-This code is a Python package that uses Psi4’s DETCI module to run Fock-space CI (RAS-nSF-IP/EA) calculations. 
+This code is a Python package that uses Psi4's DETCI module to run Fock-space CI (RAS-nSF-IP/EA) calculations. 
 The method handles spin and spatial degeneracies in molecular systems by solving the orbitals of a reference state 
 that can be well-represented by a single determinant, and then using non-particle-conserving and non-spin-conserving 
 operators to obtain the desired state.

--- a/psi4fockci/test/test_1sf.py
+++ b/psi4fockci/test/test_1sf.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "sto-3g"}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=1, 
         add_opts=options )
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -107.439176904454
     assert (e - expected) < threshold
 
@@ -32,7 +32,7 @@ def test_2():
     options = {"basis": "sto-3g"}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=3, 
         add_opts=options )
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -107.437970126831
     assert (e - expected) < threshold
 
@@ -44,7 +44,7 @@ def test_3():
     options = {"basis": "cc-pvdz"}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=1,
         add_opts=options )
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.776024394853295
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_1sf_ea.py
+++ b/psi4fockci/test/test_1sf_ea.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz"}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=-1, new_multiplicity=2, 
         add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.600832070267
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_1sf_ip.py
+++ b/psi4fockci/test/test_1sf_ip.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz"}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=1, new_multiplicity=2, 
         add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.250639579451
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_1x.py
+++ b/psi4fockci/test/test_1x.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz", 'num_roots': 4, 'diis_start': 20, 'ci_maxiter': 100}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=1,
         conf_space="1x", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.780110376393
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_S.py
+++ b/psi4fockci/test/test_S.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz"}
     wfn = run_psi4fockci('psi4fockci', o2, new_charge=0, new_multiplicity=1, 
         conf_space="S", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -149.506943097607547
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_SD.py
+++ b/psi4fockci/test/test_SD.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "6-31G", "num_roots": 4}
     wfn = run_psi4fockci('psi4fockci', o2, new_charge=0, new_multiplicity=1,
         conf_space="SD", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -149.718816902769930
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_SDT.py
+++ b/psi4fockci/test/test_SDT.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "6-31G", "num_roots": 4}
     wfn = run_psi4fockci('psi4fockci', o2, new_charge=0, new_multiplicity=1,
         conf_space="SDT", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -149.730699517793994
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_h.py
+++ b/psi4fockci/test/test_h.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz", 'num_roots': 4, 'diis_start': 20}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=1,
         conf_space="h", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.772041695171
     assert (e - expected) < threshold
 

--- a/psi4fockci/test/test_p.py
+++ b/psi4fockci/test/test_p.py
@@ -20,7 +20,7 @@ def test_1():
     options = {"basis": "cc-pvdz", 'num_roots': 4, 'diis_start': 20}
     wfn = run_psi4fockci('psi4fockci', n2, new_charge=0, new_multiplicity=1,
         conf_space="p", add_opts=options)
-    e = psi4.core.get_variable("CI ROOT 0 TOTAL ENERGY")
+    e = psi4.core.variable("CI ROOT 0 TOTAL ENERGY")
     expected = -108.773240257969
     assert (e - expected) < threshold
 


### PR DESCRIPTION
There was a non-ascii char in the README that conda balked at. I also went ahead and updated the `get_variable` to plain `variable` to squash some warnings.

Recc. squash merge